### PR TITLE
set ignoreRestSiblings to true for no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   rules: {
     'no-console': ['warn', { allow: ['error', 'warn'] }],
-    'no-unused-vars': ['error', { args: 'none' }],
+    'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
     'no-empty': ['error', { allowEmptyCatch: true }],
     'no-constant-condition': ['error', { checkLoops: false }],
     'no-bitwise': ['error', { allow: ['~'] }],


### PR DESCRIPTION
that's a common pattern with React 
```const { a, ...rest } = this.props```
without that eslint will complain if a is not used (intent here is to exclude it from `rest`)